### PR TITLE
Fix Kanban modal visibility

### DIFF
--- a/resources/views/projects/kanban.blade.php
+++ b/resources/views/projects/kanban.blade.php
@@ -80,7 +80,7 @@
         </div>
 
         <!-- Task Detail Modal -->
-        <x-modal name="task-modal" x-show="showTaskModal" max-width="2xl">
+        <x-modal name="task-modal" :show="showTaskModal" max-width="2xl">
             <div x-html="taskModalContent">
                 <div class="p-6 text-center">
                     <p>Chargement des détails de la tâche...</p>


### PR DESCRIPTION
## Summary
- fix modal toggle on Kanban board

## Testing
- `composer test` *(fails: Please install the suggested Algolia client)*

------
https://chatgpt.com/codex/tasks/task_e_688938f7c560832ba33ddcb5be79f36c